### PR TITLE
Refactor HID interfaces for portability

### DIFF
--- a/src/PLAY/Source/HIDMenu.h
+++ b/src/PLAY/Source/HIDMenu.h
@@ -47,8 +47,8 @@ public:
     //[UserMethods]     -- You can add your own custom methods in this section.
     bool HIDDeviceChanged;
     juce::String selectedKey;
-    IOHIDDeviceRef seletedDevice;
-    std::map<juce::String, IOHIDDeviceRef> devicesMap;
+    HidDeviceHandle seletedDevice;
+    std::map<juce::String, HidDeviceHandle> devicesMap;
     std::function<void()> onHIDMenuChanged;
     void ClickRefresh__textButton();
     juce::String supportDevices[5] =

--- a/src/PLAY/Source/HIDTypes.h
+++ b/src/PLAY/Source/HIDTypes.h
@@ -1,0 +1,4 @@
+#pragma once
+
+using HidDeviceHandle = void*;
+

--- a/src/PLAY/Source/HID_IO.cpp
+++ b/src/PLAY/Source/HID_IO.cpp
@@ -267,9 +267,14 @@ private:
             return;
         }
 
+        const void* rawMatchingDicts[matchingDicts.size()];
+
+        for (size_t i = 0; i < matchingDicts.size(); ++i)
+            rawMatchingDicts[i] = matchingDicts[i];
+
         CFArrayRef multiple = CFArrayCreate(kCFAllocatorDefault,
-                                            reinterpret_cast<const void**>(matchingDicts),
-                                            6,
+                                            rawMatchingDicts,
+                                            static_cast<CFIndex>(matchingDicts.size()),
                                             &kCFTypeArrayCallBacks);
 
         for (auto dict : matchingDicts)

--- a/src/PLAY/Source/HID_IO.cpp
+++ b/src/PLAY/Source/HID_IO.cpp
@@ -431,12 +431,13 @@ private:
 
         if (deviceCount > 0)
         {
-            std::vector<IOHIDDeviceRef> existingDevices(static_cast<size_t>(deviceCount));
-            CFSetGetValues(deviceSet,
-                           reinterpret_cast<const void**>(existingDevices.data()));
+            std::vector<CFTypeRef> existingDevices(static_cast<size_t>(deviceCount));
+            CFSetGetValues(deviceSet, existingDevices.data());
 
-            for (auto deviceRef : existingDevices)
+            for (auto deviceValue : existingDevices)
             {
+                auto deviceRef = static_cast<IOHIDDeviceRef>(const_cast<void*>(deviceValue));
+
                 if (deviceRef != nullptr)
                     onDeviceMatched(deviceRef);
             }

--- a/src/PLAY/Source/HID_IO.cpp
+++ b/src/PLAY/Source/HID_IO.cpp
@@ -233,7 +233,7 @@ private:
             return;
         }
 
-        CFMutableDictionaryRef matchingDicts[6] = {
+        std::vector<CFMutableDictionaryRef> matchingDicts = {
             createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick),
             createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad),
             createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_MultiAxisController),
@@ -267,14 +267,15 @@ private:
             return;
         }
 
-        const void* rawMatchingDicts[matchingDicts.size()];
+        std::vector<const void*> rawMatchingDicts;
+        rawMatchingDicts.reserve(matchingDicts.size());
 
-        for (size_t i = 0; i < matchingDicts.size(); ++i)
-            rawMatchingDicts[i] = matchingDicts[i];
+        for (auto dict : matchingDicts)
+            rawMatchingDicts.push_back(dict);
 
         CFArrayRef multiple = CFArrayCreate(kCFAllocatorDefault,
-                                            rawMatchingDicts,
-                                            static_cast<CFIndex>(matchingDicts.size()),
+                                            rawMatchingDicts.data(),
+                                            static_cast<CFIndex>(rawMatchingDicts.size()),
                                             &kCFTypeArrayCallBacks);
 
         for (auto dict : matchingDicts)

--- a/src/PLAY/Source/HID_IO.cpp
+++ b/src/PLAY/Source/HID_IO.cpp
@@ -1,277 +1,430 @@
 /*
-  ==============================================================================
+  ===============================================================================
 
     HID_IO.cpp
     Created: 21 Oct 2023 3:03:58pm
     Author:  Hongshuo Fan
 
-  ==============================================================================
+  ===============================================================================
 */
 
 #include <JuceHeader.h>
 #include "HID_IO.h"
-#include <mach/mach_error.h>
-//==============================================================================
-HID_IO::HID_IO()
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <list>
+#include <memory>
+#include <thread>
+#include <utility>
+
+class HID_IO::HidBackend
 {
-    // In your constructor, you should add any child components, and
-    // initialise any special settings that your component needs.
-//    manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-//    IOHIDManagerSetDeviceMatching(manager, NULL);
-//    IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-//    IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
-    //startReadingThread();
+public:
+    explicit HidBackend(HID_IO& ownerIn) : owner(ownerIn) {}
+    virtual ~HidBackend() = default;
 
+    virtual bool connect() = 0;
+    virtual void disconnect() = 0;
+    virtual bool writeRawData(const uint8_t* data, size_t reportId, size_t length) = 0;
+    virtual void startReadingThread() = 0;
+    virtual void stopReadingThread() = 0;
+    virtual void printReport() = 0;
 
+protected:
+    HID_IO& owner;
+};
 
+namespace
+{
+    class NullHidBackend : public HID_IO::HidBackend
+    {
+    public:
+        explicit NullHidBackend(HID_IO& ownerIn) : HidBackend(ownerIn) {}
+
+        bool connect() override
+        {
+            owner.isConneted = false;
+            return false;
+        }
+
+        void disconnect() override
+        {
+            owner.isConneted = false;
+        }
+
+        bool writeRawData(const uint8_t* data, size_t reportId, size_t length) override
+        {
+            juce::ignoreUnused(data, reportId, length);
+            return false;
+        }
+
+        void startReadingThread() override {}
+        void stopReadingThread() override {}
+        void printReport() override {}
+    };
+}
+
+#if JUCE_MAC
+
+#include <IOKit/IOKitLib.h>
+#include <IOKit/hid/IOHIDManager.h>
+#include <mach/mach_error.h>
+#include <stdexcept>
+
+class HID_IO::MacHidBackend : public HID_IO::HidBackend
+{
+public:
+    explicit MacHidBackend(HID_IO& ownerIn) : HidBackend(ownerIn) {}
+
+    ~MacHidBackend() override
+    {
+        stopReadingThread();
+    }
+
+    bool connect() override
+    {
+        if (deviceRef != nullptr)
+            disconnect();
+
+        startReadingThread();
+        return owner.isConneted;
+    }
+
+    void disconnect() override
+    {
+        if (deviceRef != nullptr)
+            deviceRef = nullptr;
+
+        owner.isConneted = false;
+    }
+
+    bool writeRawData(const uint8_t* data, size_t reportId, size_t length) override
+    {
+        IOReturn result = kIOReturnError;
+
+        if (deviceRef != nullptr)
+        {
+            result = IOHIDDeviceSetReport(deviceRef,
+                                          kIOHIDReportTypeOutput,
+                                          static_cast<CFIndex>(reportId),
+                                          data,
+                                          static_cast<CFIndex>(length));
+
+            if (result == kIOReturnSuccess)
+                return true;
+
+            std::cout << mach_error_string(result) << "\n";
+        }
+        else
+        {
+            std::cout << "IOReturn error: " << result << " - " << mach_error_string(result) << std::endl;
+        }
+
+        return false;
+    }
+
+    void startReadingThread() override
+    {
+        if (! readingThread.joinable())
+        {
+            stopThreadFlag = false;
+            readingThread = std::thread([this]() { createConnection(); });
+        }
+        else
+        {
+            owner.isConneted = false;
+        }
+    }
+
+    void stopReadingThread() override
+    {
+        if (readingThread.joinable())
+        {
+            disconnect();
+            stopThreadFlag = true;
+            readingThread.join();
+        }
+    }
+
+    void printReport() override
+    {
+        if (deviceRef != nullptr && owner.reportData != nullptr)
+        {
+            uint32_t maxInputReportSize = static_cast<uint32_t>(getIntProperty(deviceRef, CFSTR(kIOHIDMaxInputReportSizeKey)));
+            for (uint32_t i = 0; i < maxInputReportSize; ++i)
+            {
+                std::cout << i << ":";
+                printf("%02x ", owner.reportData[i]);
+            }
+            printf("\n");
+        }
+    }
+
+private:
+    struct DeviceInfo
+    {
+        MacHidBackend* backend = nullptr;
+        DeviceIdType deviceId{};
+        IOHIDDeviceRef device = nullptr;
+    };
+
+    void createConnection()
+    {
+        manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+
+        if (manager == nullptr)
+            return;
+
+        CFDictionaryRef matchingDict[6];
+        matchingDict[0] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
+        matchingDict[1] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+        matchingDict[2] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_MultiAxisController);
+        matchingDict[3] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_Pointer);
+        matchingDict[4] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_AssistiveControl);
+        matchingDict[5] = createDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_SpatialController);
+
+        CFArrayRef multiple = CFArrayCreate(kCFAllocatorDefault, (const void**) matchingDict, 6, &kCFTypeArrayCallBacks);
+
+        for (auto dict : matchingDict)
+            CFRelease(dict);
+
+        IOHIDManagerSetDeviceMatchingMultiple(manager, multiple);
+        CFRelease(multiple);
+
+        IOHIDManagerRegisterDeviceMatchingCallback(manager, &MacHidBackend::onDeviceMatchedStub, this);
+        IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
+        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetCurrent(), CFSTR("CustomLoop"));
+
+        while (CFRunLoopRunInMode(CFSTR("CustomLoop"), 1, true) != kCFRunLoopRunStopped && ! stopThreadFlag)
+        {
+            owner.isConneted = true;
+        }
+
+        IOHIDManagerClose(manager, 0);
+        owner.isConneted = false;
+        std::cout << "manager closed \n";
+        CFRelease(manager);
+        manager = nullptr;
+    }
+
+    static CFMutableDictionaryRef createDeviceMatchingDictionary(uint32_t usagePage, uint32_t usage)
+    {
+        CFMutableDictionaryRef result = CFDictionaryCreateMutable(kCFAllocatorDefault,
+                                                                   0,
+                                                                   &kCFTypeDictionaryKeyCallBacks,
+                                                                   &kCFTypeDictionaryValueCallBacks);
+
+        if (result == nullptr)
+            throw std::runtime_error("CFDictionaryCreateMutable failed.");
+
+        if (usagePage != 0)
+        {
+            CFNumberRef pageCFNumberRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usagePage);
+            if (pageCFNumberRef == nullptr)
+                throw std::runtime_error("CFNumberCreate failed.");
+
+            CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsagePageKey), pageCFNumberRef);
+            CFRelease(pageCFNumberRef);
+
+            if (usage != 0)
+            {
+                CFNumberRef usageCFNumberRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
+                if (usageCFNumberRef == nullptr)
+                    throw std::runtime_error("CFNumberCreate failed.");
+
+                CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsageKey), usageCFNumberRef);
+                CFRelease(usageCFNumberRef);
+            }
+        }
+
+        return result;
+    }
+
+    static int getIntProperty(IOHIDDeviceRef device, CFStringRef key)
+    {
+        int value = 0;
+        CFTypeRef property = IOHIDDeviceGetProperty(device, key);
+
+        if (property && CFGetTypeID(property) == CFNumberGetTypeID())
+        {
+            CFNumberRef number = static_cast<CFNumberRef>(property);
+            CFNumberGetValue(number, kCFNumberSInt32Type, &value);
+            return value;
+        }
+
+        return value;
+    }
+
+    static DeviceIdType getDeviceID(IOHIDDeviceRef dev)
+    {
+        DeviceIdType device{ 0 };
+        int vendor = getIntProperty(dev, CFSTR(kIOHIDVendorIDKey));
+        int product = getIntProperty(dev, CFSTR(kIOHIDProductIDKey));
+        int location = getIntProperty(dev, CFSTR(kIOHIDLocationIDKey));
+        device.at(0) = vendor & 0xFF;
+        device.at(1) = (vendor >> 8) & 0xFF;
+        device.at(2) = product & 0xFF;
+        device.at(3) = (product >> 8) & 0xFF;
+        device.at(4) = (location >> 16) & 0xFF;
+        device.at(5) = (location >> 24) & 0xFF;
+        return device;
+    }
+
+    static void onDeviceMatchedStub(void* context, IOReturn result, void* sender, IOHIDDeviceRef device)
+    {
+        juce::ignoreUnused(result, sender);
+        static_cast<MacHidBackend*>(context)->onDeviceMatched(device);
+    }
+
+    void onDeviceMatched(IOHIDDeviceRef device)
+    {
+        devices.emplace_back();
+
+        auto& deviceInfo = devices.back();
+        deviceInfo.backend = this;
+        deviceInfo.device = device;
+        deviceInfo.deviceId = getDeviceID(device);
+
+        CFStringRef name_cf = static_cast<CFStringRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey)));
+        CFStringEncoding encodingMethod = CFStringGetSystemEncoding();
+        const char* name = CFStringGetCStringPtr(name_cf, encodingMethod);
+
+        if (! stopThreadFlag && name)
+        {
+            if (owner.device_name != nullptr && std::strcmp(name, owner.device_name) == 0)
+            {
+                deviceRef = device;
+                uint32_t maxInputReportSize = static_cast<uint32_t>(getIntProperty(device, CFSTR(kIOHIDMaxInputReportSizeKey)));
+                uint8_t* reportBuffer = static_cast<uint8_t*>(calloc(maxInputReportSize, sizeof(uint8_t)));
+                IOHIDDeviceRegisterInputReportCallback(device,
+                                                       reportBuffer,
+                                                       maxInputReportSize,
+                                                       getCallback(),
+                                                       &deviceInfo);
+                owner.isConneted = true;
+            }
+            else
+            {
+                std::cout << name << " Not match \n";
+            }
+        }
+    }
+
+    static IOHIDReportCallback getCallback()
+    {
+        return &MacHidBackend::inputReportCallbackStub;
+    }
+
+    static void inputReportCallbackStub(void* context,
+                                        IOReturn result,
+                                        void* sender,
+                                        IOHIDReportType type,
+                                        uint32_t reportID,
+                                        uint8_t* report,
+                                        CFIndex reportLength)
+    {
+        auto* deviceInfo = reinterpret_cast<DeviceInfo*>(context);
+        deviceInfo->backend->inputReportCallback(*deviceInfo, result, sender, type, reportID, report, reportLength);
+    }
+
+    void inputReportCallback(DeviceInfo& deviceInfo,
+                             IOReturn result,
+                             void* sender,
+                             IOHIDReportType type,
+                             uint32_t reportID,
+                             uint8_t* report,
+                             CFIndex reportLength)
+    {
+        juce::ignoreUnused(deviceInfo, result, sender, type, reportID, reportLength);
+        owner.reportData = report;
+
+        if (owner.dataReceivedCallback)
+            owner.dataReceivedCallback();
+    }
+
+    IOHIDManagerRef manager = nullptr;
+    IOHIDDeviceRef deviceRef = nullptr;
+    std::list<DeviceInfo> devices;
+    std::thread readingThread;
+    bool stopThreadFlag = false;
+};
+
+#endif // JUCE_MAC
+
+namespace
+{
+    std::unique_ptr<HID_IO::HidBackend> createBackend(HID_IO& owner)
+    {
+       #if JUCE_MAC
+        return std::make_unique<HID_IO::MacHidBackend>(owner);
+       #else
+        return std::make_unique<NullHidBackend>(owner);
+       #endif
+    }
+}
+
+HID_IO::HID_IO()
+    : backend(createBackend(*this))
+{
+    device_name = nullptr;
+    reportData = nullptr;
+    OuputData = nullptr;
+    isConneted = false;
 }
 
 HID_IO::~HID_IO()
 {
     stopReadingThread();
-//    IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
-//    CFRelease(manager);
 }
 
-
-static int GetIntProperty(IOHIDDeviceRef device, CFStringRef key)
+bool HID_IO::connect()
 {
-    int value = 0;
-    CFTypeRef property = IOHIDDeviceGetProperty(device, key);
-    
-    if (property && CFGetTypeID(property) == CFNumberGetTypeID()) {
-        CFNumberRef number = static_cast<CFNumberRef>(property);
-        CFNumberGetValue(number, kCFNumberSInt32Type, &value);
-        return value;
-        // Now you can use 'number' as a CFNumberRef
-    } else {
-        // The property is not a CFNumberRef or it is NULL
-        // Handle this case accordingly
-    }
-    //CFNumberRef ref = static_cast<CFNumberRef>(IOHIDDeviceGetProperty(device, key));
-    //CFNumberGetValue(ref, kCFNumberSInt32Type, &value);
-    //CFNumberGetValue(ref, kCFNumberSInt32Type, &value);
-    
-    return value;
-}
-
-static DeviceIdType GetDeviceID(IOHIDDeviceRef dev)
-{
-    DeviceIdType device{0};
-    int vendor = GetIntProperty(dev, CFSTR(kIOHIDVendorIDKey));
-    int product = GetIntProperty(dev, CFSTR(kIOHIDProductIDKey));
-    int location = GetIntProperty(dev, CFSTR(kIOHIDLocationIDKey));
-    device.at(0) = vendor & 0xFF;
-    device.at(1) = (vendor >> 8) & 0xFF;
-    device.at(2) = product & 0xFF;
-    device.at(3) = (product >> 8) & 0xFF;
-    device.at(4) = (location >> 16) & 0xFF;
-    device.at(5) = (location >> 24) & 0xFF;
-    return device;
-}
-
-bool HID_IO::connect() {
-    
-    if(deviceRF){
-        disconnect();
-    }
-    startReadingThread();
-    
-    return isConneted;
-    
-    
-//    return false;
-}
-
-void HID_IO::disconnect() {
-    
-    if (deviceRF) {
-//           IOHIDDeviceClose(device, kIOHIDOptionsTypeNone);
-        deviceRF = NULL;
-       }
-    isConneted = false;
-}
-
-
-bool HID_IO::writeRawData(const uint8_t* data, CFIndex index, CFIndex Length){
-
-    IOReturn result = kIOReturnError;
-    if (deviceRF) {
-        result = IOHIDDeviceSetReport(deviceRF, kIOHIDReportTypeOutput, index, data, Length);
-        std::cout<< mach_error_string(result) << "\n";
-        return result == kIOReturnSuccess;
-    }else{
-        std::cout << "IOReturn error: " << result << " - " << mach_error_string(result) << std::endl;
-    }
-    return result;
-}
-
-//void HID_IO::setDataReceivedCallback(DataReceivedCallback callback) {
-//    dataReceivedCallback = callback;
-//}
-
-void HID_IO::startReadingThread() {
-    if (!readingThread.joinable()) {
-        
-        stopThreadFlag = false;
-        readingThread = std::thread([this]() {
-            creatConncet();
-        });
-        isConneted = true;
-    }else{
+    if (backend != nullptr)
+        isConneted = backend->connect();
+    else
         isConneted = false;
-    }
+
+    return isConneted;
 }
 
-void HID_IO::stopReadingThread() {
-    if (readingThread.joinable()) {
-        disconnect();
-        stopThreadFlag = true;
-        readingThread.join();
-    }
-}
-
-
-void HID_IO::creatConncet()
+void HID_IO::disconnect()
 {
-    manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-    
-    {
-        CFDictionaryRef matchingDict[6];
-        matchingDict[0] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
-        matchingDict[1] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
-        matchingDict[2] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_MultiAxisController);
-        matchingDict[3] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_Pointer);
-        matchingDict[4] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_AssistiveControl);
-        matchingDict[5] = CreateDeviceMatchingDictionary(kHIDPage_GenericDesktop, kHIDUsage_GD_SpatialController);
-        CFArrayRef multiple = CFArrayCreate(kCFAllocatorDefault, (const void**)matchingDict, 6, &kCFTypeArrayCallBacks);
-        CFRelease(matchingDict[0]);
-        CFRelease(matchingDict[1]);
-        CFRelease(matchingDict[2]);
-        CFRelease(matchingDict[3]);
-        CFRelease(matchingDict[4]);
-        CFRelease(matchingDict[5]);
-        IOHIDManagerSetDeviceMatchingMultiple(manager, multiple);
-//        CFDictionaryRef matchingDict = IOServiceMatching(kIOHIDDeviceKey);
-//        IOHIDManagerSetDeviceMatching(manager, matchingDict);
-//        CFRelease(matchingDict);
-        
-    }
-    IOHIDManagerRegisterDeviceMatchingCallback(manager, OnDeviceMatchedStub, this);
-    IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
-    IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetCurrent(), CFSTR("CustomLoop"));
-    while(CFRunLoopRunInMode(CFSTR("CustomLoop"), 1, true) != kCFRunLoopRunStopped && !stopThreadFlag){
-//        std::cout<<"CFRunLoopRunInMode \n";
-        isConneted = true;
-    }
-    
-    IOHIDManagerClose(manager, 0);
+    if (backend != nullptr)
+        backend->disconnect();
+
     isConneted = false;
-    std::cout<<"manager closed \n";
-    //stopReadingThread();
 }
 
-CFMutableDictionaryRef HID_IO::CreateDeviceMatchingDictionary(uint32_t usagePage, uint32_t usage)
+bool HID_IO::writeRawData(const uint8_t* data, size_t reportId, size_t length)
 {
-    CFMutableDictionaryRef result = CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
-    if(result == nullptr) throw std::runtime_error("CFDictionaryCreateMutable failed.");
-    if(usagePage != 0)
-    {
-        // Add key for device type to refine the matching dictionary.
-        CFNumberRef pageCFNumberRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usagePage);
-        if(pageCFNumberRef == nullptr) throw std::runtime_error("CFNumberCreate failed.");
-        CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsagePageKey), pageCFNumberRef);
-        CFRelease(pageCFNumberRef);
-        // note: the usage is only valid if the usage page is also defined
-        if(usage != 0){
-            CFNumberRef usageCFNumberRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
-            if(usageCFNumberRef == nullptr) throw std::runtime_error("CFNumberCreate failed.");
-            CFDictionarySetValue(result, CFSTR(kIOHIDDeviceUsageKey), usageCFNumberRef);
-            CFRelease(usageCFNumberRef);
-        }
-    }
-    return result;
+    if (backend != nullptr)
+        return backend->writeRawData(data, reportId, length);
+
+    return false;
 }
 
-void HID_IO::OnDeviceMatchedStub(void* context, IOReturn result, void* sender, IOHIDDeviceRef device)
+void HID_IO::setDataReceivedCallback(DataReceivedCallback callback)
 {
-    reinterpret_cast<HID_IO*>(context)->OnDeviceMatched(result, sender, device);
+    dataReceivedCallback = std::move(callback);
 }
 
-void HID_IO::OnDeviceMatched(IOReturn result, void* sender, IOHIDDeviceRef device)
+void HID_IO::startReadingThread()
 {
-    m_devices.push_back(DEVICE_INFO());
-    
-    auto& deviceInfo = *m_devices.rbegin();
-    deviceInfo.provider = this;
-    deviceInfo.device = device;
-    deviceInfo.deviceId = GetDeviceID(device);
-    
-    //std::cout<< "check "<< device_name  <<" is match? \n";
-   
-    
-    CFStringRef name_cf = static_cast<CFStringRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDProductKey)));
-    CFStringEncoding encodingMethod = CFStringGetSystemEncoding();
-    const char *name = CFStringGetCStringPtr(name_cf, encodingMethod);
-    
-    //std::cout<< "check "<< name  <<" is match? \n";
-    
-    if(!stopThreadFlag && name){
-        if (strcmp(name, device_name) == 0){
-            
-            deviceRF = device;
-            uint32_t max_input_report_size = GetIntProperty(device, CFSTR(kIOHIDMaxInputReportSizeKey));
-            uint8_t* report_buffer = static_cast<uint8_t*>(calloc(max_input_report_size, sizeof(uint8_t)));
-            auto InputReportCallbackStub = GetCallback(device);
-            IOHIDDeviceRegisterInputReportCallback(device, report_buffer, max_input_report_size, InputReportCallbackStub, &deviceInfo);
-//            std::cout<< name <<" is available \n";
-//            std::cout<< max_input_report_size <<"  max_input_report_size \n";
-            isConneted = true;
-            return ;
-        }else{
-            
-            std::cout<< name <<" Not match \n";
-           
-            return;
-        }
-        
-        //    CFStringRef size_cf = static_cast<CFStringRef>(IOHIDDeviceGetProperty(device, CFSTR(kIOHIDMaxInputReportSizeKey)));
-        return;
-    }
-   
+    if (backend != nullptr)
+        backend->startReadingThread();
 }
 
-IOHIDReportCallback HID_IO::GetCallback(IOHIDDeviceRef device){
-    return &InputReportCallbackStub;
-}
-
-void HID_IO::InputReportCallbackStub(void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength){
-
-    auto deviceInfo = reinterpret_cast<DEVICE_INFO*>(context);
-    deviceInfo->provider->InputReportCallback(deviceInfo, result, sender, type, reportID, report, reportLength);
-    
-}
-
-void HID_IO::InputReportCallback(DEVICE_INFO* deviceInfo, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
+void HID_IO::stopReadingThread()
 {
-    reportData = report;
-    //printReport();
-    dataReceivedCallback();
-    
-//    std::cout<<  report[1] << "\n";
+    if (backend != nullptr)
+        backend->stopReadingThread();
 }
 
-void HID_IO::printReport() {
-    if(deviceRF){
-        
-        uint8_t* packet = reportData;
-        uint32_t max_input_report_size = GetIntProperty(deviceRF, CFSTR(kIOHIDMaxInputReportSizeKey));
-        for(int i = 0; i < max_input_report_size; i++){
-            std::cout<< i << ":";
-            printf("%02x ", packet[i]);
-        }
-        printf("\n");
-    }
+void HID_IO::printReport()
+{
+    if (backend != nullptr)
+        backend->printReport();
 }
-
-

--- a/src/PLAY/Source/HID_IO.h
+++ b/src/PLAY/Source/HID_IO.h
@@ -58,6 +58,13 @@ public:
 
 private:
     class HidBackend;
+    class NullHidBackend;
+#if JUCE_MAC
+    class MacHidBackend;
+#endif
+
+    static std::unique_ptr<HidBackend> createBackend(HID_IO& owner);
+
     std::unique_ptr<HidBackend> backend;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (HID_IO)

--- a/src/PLAY/Source/HID_IO.h
+++ b/src/PLAY/Source/HID_IO.h
@@ -14,12 +14,9 @@
 #include "InputProvider.h"
 #include "HIDTypes.h"
 #include <JuceHeader.h>
-#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <memory>
-#include <thread>
-#include <vector>
 
 //==============================================================================
 /*

--- a/src/PLAY/Source/HID_IO.h
+++ b/src/PLAY/Source/HID_IO.h
@@ -11,15 +11,16 @@
 #pragma once
 
 
-#include <IOKit/hid/IOHIDManager.h>
-#include <IOKit/IOKitLib.h>
 #include "InputProvider.h"
-#include <iostream>
-#include <functional>
-#include <thread>
-#include <chrono>
-#include <vector>
+#include "HIDTypes.h"
 #include <JuceHeader.h>
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <vector>
+
 //==============================================================================
 /*
  */
@@ -29,64 +30,35 @@ class HID_IO  : public juce::Component
 {
 public:
 
-    using DataReceivedCallback = std::function<void(const std::vector<unsigned char>&)>;
-    
+    using DataReceivedCallback = std::function<void()>;
+
     HID_IO();
     ~HID_IO() override;
 
     char *device_name;
- 
+
     bool connect();
     void disconnect();
     bool isConneted;
-    
-    bool writeRawData(const uint8_t* data, CFIndex index, CFIndex Length);
+
+    bool writeRawData(const uint8_t* data, size_t reportId, size_t length);
 //    bool readRawData(unsigned char* buffer, int bufferSize);
-    
+
     void setDataReceivedCallback(DataReceivedCallback callback);
-    
+
     void startReadingThread();
     void stopReadingThread();
-    
+
     void printReport();
-    
+
     uint8_t* reportData;
     uint8_t* OuputData;
-    
+
     std::function<void()> dataReceivedCallback;
-    
+
 private:
-    IOHIDManagerRef manager;
-    IOHIDDeviceRef deviceRF;
-    
-    struct DEVICE_INFO
-    {
-        HID_IO* provider = nullptr;
-        DeviceIdType deviceId;
-        IOHIDDeviceRef device;
-        //      *  bool first_run = true;
-//        uint8_t prev_btn_state[50];
-    };
-    
-    
-    
-    //DataReceivedCallback dataReceivedCallback;
-    
-    void creatConncet();
-    
-    CFMutableDictionaryRef CreateDeviceMatchingDictionary(uint32_t usagePage, uint32_t usage);
-    
-    static void OnDeviceMatchedStub(void* context, IOReturn result, void* sender, IOHIDDeviceRef device);
-    void OnDeviceMatched(IOReturn result, void* sender, IOHIDDeviceRef device);
-    
-    IOHIDReportCallback GetCallback(IOHIDDeviceRef device);
-    static void InputReportCallbackStub(void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength);
-    void InputReportCallback(DEVICE_INFO* deviceInfo, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength);
-    
-    std::list<DEVICE_INFO> m_devices;
-    
-    std::thread readingThread;
-    bool stopThreadFlag;
-   
+    class HidBackend;
+    std::unique_ptr<HidBackend> backend;
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (HID_IO)
 };

--- a/src/PLAY/Source/ListHID.h
+++ b/src/PLAY/Source/ListHID.h
@@ -11,8 +11,9 @@
 #pragma once
 
 #include <JuceHeader.h>
-#include <IOKit/IOKitLib.h>
-#include <IOKit/hid/IOHIDManager.h>
+#include "HIDTypes.h"
+#include <map>
+#include <set>
 
 //==============================================================================
 /*
@@ -28,8 +29,8 @@ public:
     
     void get_hid_list();
     
-    std::set<IOHIDDeviceRef> uniqueDevices;
-    std::map<juce::String, IOHIDDeviceRef> devicesMap;
+    std::set<HidDeviceHandle> uniqueDevices;
+    std::map<juce::String, HidDeviceHandle> devicesMap;
     
 private:
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ListHID)

--- a/src/PLAY/Source/Main.cpp
+++ b/src/PLAY/Source/Main.cpp
@@ -7,6 +7,13 @@
 */
 
 #include <JuceHeader.h>
+
+#if ! JUCE_MAC
+# include "HID_IO.h"
+# include "ListHID.h"
+# include "HIDMenu.h"
+#endif
+
 #include "MainComponent.h"
 
 //==============================================================================


### PR DESCRIPTION
## Summary
- introduce a backend abstraction for HID_IO so the public header no longer exposes macOS-only types
- add a shared HidDeviceHandle alias and update ListHID/HIDMenu to store opaque handles with macOS code wrapped in JUCE_MAC guards
- include the revised HID headers from a non-mac translation unit to verify they build when JUCE_MAC is false

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cf1ee795fc832283763bfa7ec7cc90